### PR TITLE
Feature/add attribute for hotwater schedule status

### DIFF
--- a/custom_components/nest_legacy/pynest/models.py
+++ b/custom_components/nest_legacy/pynest/models.py
@@ -128,6 +128,7 @@ class NestThermostat(NestDevice):
     heat_link_serial_number: str | None = None
     heat_link_sw_version: str | None = None
     hot_water_active: bool = False
+    hot_water_control_active: bool = False
     has_hot_water_temperature: bool = False
     hot_water_mode: HotWaterMode = HotWaterMode.OFF
     hot_water_away_enabled: bool = False
@@ -183,6 +184,7 @@ class NestHeatLink(NestDevice):
     associated_thermostat_object_key: str | None = None
     has_hot_water_control: bool = False
     hot_water_active: bool = False
+    hot_water_control_active: bool = False
     has_hot_water_temperature: bool = False
     hot_water_boost_time_to_end: int = 0
     hot_water_mode: HotWaterMode = HotWaterMode.OFF

--- a/custom_components/nest_legacy/pynest/parser.py
+++ b/custom_components/nest_legacy/pynest/parser.py
@@ -1229,6 +1229,7 @@ class NestParser:
         self, traits: dict[str, Any], temp_scale: TemperatureScale | None
     ) -> tuple[
         bool,
+        bool,
         int,
         float | None,
         float | None,
@@ -1247,6 +1248,7 @@ class NestParser:
         )
 
         hot_water_active = False
+        hot_water_control_active = False
         hot_water_boost_time_to_end = 0
         hot_water_temperature = None
         current_water_temperature = None
@@ -1255,6 +1257,7 @@ class NestParser:
 
         if hw_trait:
             hot_water_active = hw_trait.boilerActive
+            hot_water_control_active = hw_trait.controlActive
             if hw_trait.HasField("temperature"):
                 current_water_temperature = _round_temp(
                     hw_trait.temperature.value, temp_scale
@@ -1295,6 +1298,7 @@ class NestParser:
 
         return (
             hot_water_active,
+            hot_water_control_active,
             hot_water_boost_time_to_end,
             hot_water_temperature,
             current_water_temperature,
@@ -1553,6 +1557,7 @@ class NestParser:
         # Hot Water / Heat Link Parsing
         (
             hot_water_active,
+            hot_water_control_active,
             hot_water_boost_time_to_end,
             hot_water_temperature,
             current_water_temperature,
@@ -1629,6 +1634,7 @@ class NestParser:
             if has_hot_water_control
             else None,
             hot_water_active=hot_water_active,
+            hot_water_control_active=hot_water_control_active,
             hot_water_boost_time_to_end=hot_water_boost_time_to_end,
             hot_water_temperature=hot_water_temperature,
             current_water_temperature=current_water_temperature,
@@ -2418,6 +2424,7 @@ class NestParser:
             associated_thermostat_object_key=thermostat.object_key,
             has_hot_water_control=thermostat.has_hot_water_control,
             hot_water_active=thermostat.hot_water_active,
+            hot_water_control_active=thermostat.hot_water_control_active,
             has_hot_water_temperature=thermostat.has_hot_water_temperature,
             hot_water_boost_time_to_end=thermostat.hot_water_boost_time_to_end,
             hot_water_mode=thermostat.hot_water_mode,

--- a/custom_components/nest_legacy/water_heater.py
+++ b/custom_components/nest_legacy/water_heater.py
@@ -128,6 +128,7 @@ class NestHeatLinkWaterHeater(NestEntity[NestHeatLink], WaterHeaterEntity):
         """Return the optional state attributes."""
         attrs: dict[str, Any] = {
             "boiler_active": self.device.hot_water_active,
+            "hot_water_schedule_active": self.device.hot_water_control_active,
         }
         if self.device.hot_water_boost_time_to_end > 0:
             attrs["boost_timer_end"] = datetime.datetime.fromtimestamp(


### PR DESCRIPTION
**Summary**

Adding in an extra attribute to the Heat Link. Currently none of the attributes reflect whether the Nest has the hot water in "On" mode (which comes from the schedule), you can only see if it's got a 30 or 60 minute boost. 

Adding this attribute is helpful as it allows automations within HomeAssistant if the hot water schedule is currently active. Or setting things like booleans which can be used in HomeKit (my use case). 