### PR TITLE
Fix blank serial fallback for protobuf devices

### DIFF
--- a/custom_components/nest_legacy/pynest/models.py
+++ b/custom_components/nest_legacy/pynest/models.py
@@ -34,6 +34,11 @@ class NestDevice:
     is_protobuf: bool = False
     battery_voltage: float | None = None
 
+    def __post_init__(self) -> None:
+        """Use object key as a stable fallback when the API omits serial number."""
+        if not self.serial_number:
+            object.__setattr__(self, "serial_number", self.object_key)
+
     @property
     def hardware_version(self) -> str | None:
         """Return hardware version if available."""


### PR DESCRIPTION
Fix protobuf devices with missing or blank serial numbers by falling back to the Nest API object key.

## Why

Some protobuf resources can include an empty `DeviceIdentityTrait` / blank `serialNumber`. The integration uses `device.serial_number` as the device identifier and coordinator key, so multiple protobuf devices with blank serials can collapse into a single processed device.

This was observed with Nest Temperature Sensors where multiple `DEVICE_*` resources parsed with `serial_number == ""`.

## Change

Adds a `NestDevice.__post_init__()` fallback:

```python
if not self.serial_number:
    object.__setattr__(self, "serial_number", self.object_key)