### PR TITLE
Fix protobuf devices with missing or blank serial numbers by falling back to the Nest API object key, and relax the protobuf temperature sensor beacon timeout.

### DIFF
--- a/custom_components/nest_legacy/pynest/models.py
+++ b/custom_components/nest_legacy/pynest/models.py
@@ -34,6 +34,11 @@ class NestDevice:
     is_protobuf: bool = False
     battery_voltage: float | None = None
 
+    def __post_init__(self) -> None:
+        """Use the object key when the API omits a usable serial number."""
+        if not self.serial_number or not self.serial_number.strip():
+            object.__setattr__(self, "serial_number", self.object_key)
+            
     @property
     def hardware_version(self) -> str | None:
         """Return hardware version if available."""

--- a/custom_components/nest_legacy/pynest/parser.py
+++ b/custom_components/nest_legacy/pynest/parser.py
@@ -2267,7 +2267,7 @@ class NestParser:
         if beacon_trait and beacon_trait.HasField("lastBeaconTime"):
             online = (
                 time.time() - _safe_to_seconds(beacon_trait.lastBeaconTime)
-            ) < 3600 * 4
+            ) < 7200 * 4
         elif liveness_trait:
             online = (
                 liveness_trait.status


### PR DESCRIPTION
## Why

Some protobuf resources can include an empty `DeviceIdentityTrait` / blank `serialNumber`. The integration uses `device.serial_number` as the device identifier and coordinator key, so multiple protobuf devices with blank serials can collapse into a single processed device.

This was observed with Nest Temperature Sensors where multiple `DEVICE_*` resources parsed with `serial_number == ""`.

Example impact:

- Multiple protobuf temperature sensors are received from the Nest API.
- Each has an empty `DeviceIdentityTrait` / blank `serialNumber`.
- The coordinator stores them using the same empty-string key.
- Only one sensor survives in processed data, so the others are not added correctly.

A second issue was observed after the devices were no longer collapsing: some protobuf Nest Temperature Sensors could still report valid temperature and battery data, but be marked unavailable because their `lastBeaconTime` was slightly older than the current 4-hour online cutoff.

## Change

Adds a `NestDevice.__post_init__()` fallback:

```python
if not self.serial_number:
    object.__setattr__(self, "serial_number", self.object_key)