### PR TITLE
Treat transient HTTP errors as retryable instead of bad credentials

### DIFF
--- a/custom_components/nest_legacy/pynest/client.py
+++ b/custom_components/nest_legacy/pynest/client.py
@@ -26,6 +26,7 @@ from .exceptions import (
     BadGatewayException,
     EmptyResponseException,
     GatewayTimeoutException,
+    NestServiceException,
     NonRetryablePynestException,
     NotAuthenticatedException,
     PynestException,
@@ -359,6 +360,20 @@ def _get_trait_copy(traits: dict[str, Any] | None, trait_class: type[_T]) -> _T:
     return trait_class()
 
 
+def _is_transient_status(status: int) -> bool:
+    """Return True if an HTTP status is a transport failure, not an auth failure."""
+    return status >= 500 or status in (408, 429)
+
+
+def _transient_exception(status: int, message: str) -> NestServiceException:
+    """Return the service exception matching a transient HTTP status."""
+    if status == 504:
+        return GatewayTimeoutException(message)
+    if status == 502:
+        return BadGatewayException(message)
+    return NestServiceException(message)
+
+
 class NestClient:
     """Interface class for the Nest API."""
 
@@ -506,10 +521,22 @@ class NestClient:
                 data=f"access_token={access_token}",
             ) as response:
                 if not response.ok:
+                    body = await response.text()
+                    if _is_transient_status(response.status):
+                        _LOGGER.info(
+                            "Transient error getting camera session token, will "
+                            "retry. Status: %s, Body: %s",
+                            response.status,
+                            body,
+                        )
+                        raise _transient_exception(
+                            response.status,
+                            f"Failed to get camera session token: {response.status}",
+                        )
                     _LOGGER.error(
                         "Failed to get camera session token. Status: %s, Body: %s",
                         response.status,
-                        await response.text(),
+                        body,
                     )
                     raise BadCredentialsException("Failed to get camera session token")
 
@@ -539,14 +566,27 @@ class NestClient:
             headers={"Authorization": f"Basic {token}", "User-Agent": _USER_AGENT},
         ) as response:
             if not response.ok:
+                body = await response.text()
+                message = f"Failed to get session: {response.status}"
+                # A 5xx/408/429 is a server-side failure, not a bad credential.
+                # Raising BadCredentialsException here makes the coordinator
+                # start a reauth flow and stop the subscriber for what is often
+                # a transient blip, even though the stored credentials are
+                # still valid.
+                if _is_transient_status(response.status):
+                    _LOGGER.info(
+                        "Transient error getting session, will retry. "
+                        "Status: %s, Body: %s",
+                        response.status,
+                        body,
+                    )
+                    raise _transient_exception(response.status, message)
                 _LOGGER.error(
                     "Failed to get session. Status: %s, Body: %s",
                     response.status,
-                    await response.text(),
+                    body,
                 )
-                raise BadCredentialsException(
-                    f"Failed to get session: {response.status}"
-                )
+                raise BadCredentialsException(message)
             nest_session_dict = await response.json()
             self._nest_session = NestSession.from_dict(nest_session_dict)
             _LOGGER.debug(


### PR DESCRIPTION
## Problem

`_async_get_session()` raises `BadCredentialsException` on **any** non-2xx response:

```python
if not response.ok:
    _LOGGER.error("Failed to get session. Status: %s, Body: %s", response.status, await response.text())
    raise BadCredentialsException(f"Failed to get session: {response.status}")
```

`coordinator.py` turns that into `config_entry.async_start_reauth()` + `async_stop_subscriber()` (and `ConfigEntryAuthFailed` on the setup path), so a **server-side 5xx takes the integration down until the user manually re-enters credentials** — credentials that were never invalid.

I hit this with a single 504 from `home.nest.com/session`:

```
ERROR ... [pynest] Failed to get session. Status: 504, Body:
ERROR ... [coordinator] Bad credentials, re-authentication required
```

The credentials were fine. I replayed the whole chain read-only afterwards with the same stored `issue_token`/`cookies` — `issueToken` 200, `issue_jwt` 200, `/session` 200 reporting an expiry a month out, `app_launch` 200 returning live `topaz` and `kryptonite` buckets. Re-enabling the config entry with the unchanged credentials came straight back to `state=loaded`; no re-extraction was needed. The credentials had been in place, untouched, for 95 days.

The failure mode is unpleasant because the message is convincing: it tells the user to redo the browser cookie extraction, which is the one maintenance step everyone dreads, for a blip that would have cleared itself in a minute.

## Change

Route `5xx`/`408`/`429` to the existing `NestServiceException` family and keep `BadCredentialsException` for genuine 4xx rejections:

```python
def _is_transient_status(status: int) -> bool:
def _transient_exception(status: int, message: str) -> NestServiceException:   # 504 -> Gateway, 502 -> BadGateway
```

This is deliberately not a new policy — it aligns two outliers with the convention already in the file:

- `_async_update_objects()` separates `401`/`403` from other 4xx and already treats `429` as retryable.
- `_async_subscribe_for_updates()` already maps `504` → `GatewayTimeoutException` and `502` → `BadGatewayException`.

`_async_get_camera_session_token()` had the identical collapse-everything-into-bad-credentials shape, so it gets the same treatment for consistency.

**No coordinator change is needed.** `NestServiceException` is a `PynestException`, so the subscriber's existing handler retries it with exponential backoff and marks the subscriber unhealthy after 3 failures, while the setup path raises `UpdateFailed` instead of `ConfigEntryAuthFailed`.

## Verification

The repo has no test suite, so I checked both directions offline with a fake session object (no server, no TLS). A guard that swallows a genuinely dead cookie would be worse than the bug, so the 4xx half matters as much as the 5xx half:

| status | `_async_get_session` | `_async_get_camera_session_token` | behaviour |
|---|---|---|---|
| 504 | `GatewayTimeoutException` | `GatewayTimeoutException` | retry |
| 502 | `BadGatewayException` | `BadGatewayException` | retry |
| 500 / 503 / 429 / 408 | `NestServiceException` | `NestServiceException` | retry |
| 400 / 401 / 403 / 404 / 418 | `BadCredentialsException` | `BadCredentialsException` | reauth |

22/22 as expected; 4xx still logs at `ERROR` and still starts the reauth flow. `ruff format` reports no diff, and the change adds no new lint rule classes beyond the same `PLR2004` literal-status comparisons already used throughout the file.

Running the patched version live now; Protect and Kryptonite sensors are healthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vh7eFr2N2AeQmyhQHb4t3z
