### PR TITLE
Added translations for error messages

### DIFF
--- a/custom_components/nest_legacy/coordinator.py
+++ b/custom_components/nest_legacy/coordinator.py
@@ -155,7 +155,9 @@ class NestCoordinator(DataUpdateCoordinator[dict[str, NestDevice]]):
                 )
             else:
                 raise HomeAssistantError(
-                    f"Unsupported account type in config entry: {account_type}"
+                    translation_domain=DOMAIN,
+                    translation_key="unsupported_account_type",
+                    translation_placeholders={"account_type": str(account_type)},
                 )
 
     async def async_initialize(self) -> None:
@@ -220,7 +222,8 @@ class NestCoordinator(DataUpdateCoordinator[dict[str, NestDevice]]):
                 )
             except (ClientError, TimeoutError, PynestException) as err:
                 raise HomeAssistantError(
-                    "Retry failed after re-authentication"
+                    translation_domain=DOMAIN,
+                    translation_key="command_retry_failed",
                 ) from err
         except (ClientError, TimeoutError, PynestException) as err:
             _LOGGER.error(
@@ -231,7 +234,11 @@ class NestCoordinator(DataUpdateCoordinator[dict[str, NestDevice]]):
                 data,
                 err,
             )
-            raise HomeAssistantError from err
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="set_data_failed",
+                translation_placeholders={"device_name": device.name},
+            ) from err
 
     async def async_send_client_command(
         self,
@@ -253,11 +260,16 @@ class NestCoordinator(DataUpdateCoordinator[dict[str, NestDevice]]):
                 return await method(*args, **kwargs)
             except (ClientError, TimeoutError, PynestException) as err:
                 raise HomeAssistantError(
-                    "Retry failed after re-authentication"
+                    translation_domain=DOMAIN,
+                    translation_key="command_retry_failed",
                 ) from err
         except (ClientError, TimeoutError, PynestException) as err:
             _LOGGER.error("Error calling %s: %r", method_name, err)
-            raise HomeAssistantError from err
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="command_failed",
+                translation_placeholders={"method_name": method_name},
+            ) from err
 
     def get_guests(self) -> dict[str, list[dict[str, Any]]]:
         """Return guests from the raw protobuf data, keyed by structure ID."""

--- a/custom_components/nest_legacy/services.py
+++ b/custom_components/nest_legacy/services.py
@@ -43,20 +43,29 @@ def async_setup_services(hass: HomeAssistant) -> None:
         if not config_entry_id:
             entries = hass.config_entries.async_entries(DOMAIN)
             if not entries:
-                raise ServiceValidationError("No Nest Legacy integration found")
+                raise ServiceValidationError(
+                    translation_domain=DOMAIN, translation_key="no_config_entry"
+                )
             if len(entries) > 1:
                 raise ServiceValidationError(
-                    "Multiple Nest Legacy integrations found, please specify config_entry_id"
+                    translation_domain=DOMAIN,
+                    translation_key="multiple_config_entries",
                 )
             entry = entries[0]
         else:
             entry = hass.config_entries.async_get_entry(config_entry_id)
 
         if not entry:
-            raise ServiceValidationError(f"Config entry '{config_entry_id}' not found")
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="config_entry_not_found",
+                translation_placeholders={"config_entry_id": str(config_entry_id)},
+            )
 
         if not hasattr(entry, "runtime_data") or not entry.runtime_data:
-            raise ServiceValidationError("Nest Legacy integration not ready")
+            raise ServiceValidationError(
+                translation_domain=DOMAIN, translation_key="integration_not_ready"
+            )
         return entry.runtime_data
 
     def _get_serial_from_ha_device(ha_device_id: str) -> str:
@@ -65,7 +74,9 @@ def async_setup_services(hass: HomeAssistant) -> None:
         device_entry = device_registry.async_get(ha_device_id)
         if not device_entry:
             raise ServiceValidationError(
-                f"Device ID '{ha_device_id}' not found in registry"
+                translation_domain=DOMAIN,
+                translation_key="device_not_found",
+                translation_placeholders={"device_id": ha_device_id},
             )
 
         for domain, identifier in device_entry.identifiers:
@@ -73,7 +84,9 @@ def async_setup_services(hass: HomeAssistant) -> None:
                 return identifier
 
         raise ServiceValidationError(
-            f"Device '{ha_device_id}' is not a Nest Legacy device"
+            translation_domain=DOMAIN,
+            translation_key="device_not_nest_legacy",
+            translation_placeholders={"device_id": ha_device_id},
         )
 
     async def async_list_guests(call: ServiceCall) -> ServiceResponse:

--- a/custom_components/nest_legacy/strings.json
+++ b/custom_components/nest_legacy/strings.json
@@ -278,6 +278,38 @@
       }
     }
   },
+  "exceptions": {
+    "command_failed": {
+      "message": "Error calling {method_name}."
+    },
+    "command_retry_failed": {
+      "message": "Retry failed after re-authentication."
+    },
+    "config_entry_not_found": {
+      "message": "Config entry {config_entry_id} not found."
+    },
+    "device_not_found": {
+      "message": "Device ID {device_id} not found in registry."
+    },
+    "device_not_nest_legacy": {
+      "message": "Device {device_id} is not a Nest Legacy device."
+    },
+    "integration_not_ready": {
+      "message": "Nest Legacy integration not ready."
+    },
+    "multiple_config_entries": {
+      "message": "Multiple Nest Legacy integrations found, please specify config_entry_id."
+    },
+    "no_config_entry": {
+      "message": "No Nest Legacy integration found."
+    },
+    "set_data_failed": {
+      "message": "Error setting data for Nest device {device_name}."
+    },
+    "unsupported_account_type": {
+      "message": "Unsupported account type in config entry: {account_type}."
+    }
+  },
   "options": {
     "step": {
       "user": {

--- a/custom_components/nest_legacy/translations/en.json
+++ b/custom_components/nest_legacy/translations/en.json
@@ -278,6 +278,38 @@
             }
         }
     },
+    "exceptions": {
+        "command_failed": {
+            "message": "Error calling {method_name}."
+        },
+        "command_retry_failed": {
+            "message": "Retry failed after re-authentication."
+        },
+        "config_entry_not_found": {
+            "message": "Config entry {config_entry_id} not found."
+        },
+        "device_not_found": {
+            "message": "Device ID {device_id} not found in registry."
+        },
+        "device_not_nest_legacy": {
+            "message": "Device {device_id} is not a Nest Legacy device."
+        },
+        "integration_not_ready": {
+            "message": "Nest Legacy integration not ready."
+        },
+        "multiple_config_entries": {
+            "message": "Multiple Nest Legacy integrations found, please specify config_entry_id."
+        },
+        "no_config_entry": {
+            "message": "No Nest Legacy integration found."
+        },
+        "set_data_failed": {
+            "message": "Error setting data for Nest device {device_name}."
+        },
+        "unsupported_account_type": {
+            "message": "Unsupported account type in config entry: {account_type}."
+        }
+    },
     "options": {
         "step": {
             "user": {


### PR DESCRIPTION
## Whats changed

A more scoped version of #62

Converted the plain-string errors in services.py/coordinator.py to use translation keys instead, so they can actually be localized instead of being hardcoded to English

🤖 Vibecoded with [Claude Code](https://claude.com/claude-code)